### PR TITLE
Show file title in thumbnail popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OctoPrint-UltimakerFormatPackage
 
-**TODO:** Describe what your plugin does.
+This plugin adds support for Ultimaker Format Package (.ufp) files. Ultimaker Format Package files are based on Open Packaging Conventions (OPC) and contain compressed gcode and a preview thumbnail. The preview thumbnail can be shown in OctoPrint from the files list.
 
 ## Setup
 
@@ -8,10 +8,3 @@ Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wik
 or manually using this URL:
 
     https://github.com/jneilliii/OctoPrint-UltimakerFormatPackage/archive/master.zip
-
-**TODO:** Describe how to install your plugin, if more needs to be done than just installing it via pip or through
-the plugin manager.
-
-## Configuration
-
-**TODO:** Describe your plugin's configuration options (if any).

--- a/octoprint_ultimakerformatpackage/__init__.py
+++ b/octoprint_ultimakerformatpackage/__init__.py
@@ -41,7 +41,7 @@ class UltimakerFormatPackagePlugin(octoprint.plugin.SettingsPlugin,
 				entry = QueueEntry(payload["name"] + ".gcode",payload["path"] + ".gcode","gcode",payload["storage"],new_name, printer_profile, None)
 			else:
 				entry = QueueEntry(payload["name"] + ".gcode",payload["path"] + ".gcode","gcode",payload["storage"],new_name, printer_profile)
-			self._analysis_queue.enqueue(entry,high_priority=True) 
+			self._analysis_queue.enqueue(entry,high_priority=True)
 		if event == "FileRemoved" and payload["name"].endswith(".ufp.gcode"):
 			thumbnail = "%s/%s" % (self.get_plugin_data_folder(), payload["name"].replace(".ufp.gcode", ".png"))
 			ufp_file = "%s/%s" % (self.get_plugin_data_folder(), payload["name"].replace(".ufp.gcode", ".ufp"))

--- a/octoprint_ultimakerformatpackage/static/css/UltimakerFormatPackage.css
+++ b/octoprint_ultimakerformatpackage/static/css/UltimakerFormatPackage.css
@@ -1,1 +1,8 @@
-/* TODO: Have your plugin's CSS files generated to here. */
+#thumbnail_viewer {
+	width: 330px;
+	margin-left: -165px;
+}
+
+#thumbnail_viewer h3 {
+	overflow: hidden;
+}

--- a/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
+++ b/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
@@ -7,15 +7,18 @@
 $(function() {
 	function UltimakerformatpackageViewModel(parameters) {
 		var self = this;
-		self.current_file = ko.observable('/static/img/tentacle-20x20.png');
+		self.thumbnail_url = ko.observable('/static/img/tentacle-20x20.png');
+		self,thumbnail_title = ko.observable('');
 
 		self.settingsViewModel = parameters[0];
 		self.filesViewModel = parameters[1];
 
 		self.filesViewModel.open_thumbnail = function(data) {
 			if(data.name.indexOf('.ufp.gcode') > 0){
+				var thumbnail_title = data.name.replace('.ufp.gcode','.ufp');
 				var thumbnail_url = '/plugin/UltimakerFormatPackage/' + data.name.replace('.ufp.gcode','.png');
-				self.current_file(thumbnail_url);
+				self.thumbnail_url(thumbnail_url);
+				self.thumbnail_title(thumbnail_title);
 				$('div#thumbnail_viewer').modal("show");
 			}
 		}

--- a/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
+++ b/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
@@ -8,7 +8,7 @@ $(function() {
 	function UltimakerformatpackageViewModel(parameters) {
 		var self = this;
 		self.thumbnail_url = ko.observable('/static/img/tentacle-20x20.png');
-		self,thumbnail_title = ko.observable('');
+		self.thumbnail_title = ko.observable('');
 
 		self.settingsViewModel = parameters[0];
 		self.filesViewModel = parameters[1];

--- a/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
+++ b/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
@@ -15,7 +15,6 @@ $(function() {
 		self.filesViewModel.open_thumbnail = function(data) {
 			if(data.name.indexOf('.ufp.gcode') > 0){
 				var thumbnail_url = '/plugin/UltimakerFormatPackage/' + data.name.replace('.ufp.gcode','.png');
-				console.log(thumbnail_url);
 				self.current_file(thumbnail_url);
 				$('div#thumbnail_viewer').modal("show");
 			}

--- a/octoprint_ultimakerformatpackage/templates/UltimakerFormatPackage.jinja2
+++ b/octoprint_ultimakerformatpackage/templates/UltimakerFormatPackage.jinja2
@@ -1,10 +1,10 @@
 <div id="thumbnail_viewer" class="modal hide fade">
 	<div class="modal-header">
 		<a href="#" class="close" data-dismiss="modal" aria-hidden="true">&times;</a>
-		<h3>{{ _('Ultimaker Format Package') }}</h3>
+		<h3 data-bind="text: thumbnail_title()"></h3>
 	</div>
 	<div class="modal-body">
-		<img data-bind="attr: {src: current_file()}" width="100%"/>
+		<img data-bind="attr: {src: thumbnail_url()}" width="100%"/>
 	</div>
 	<div class="modal-footer">
 		<a href="#" class="btn btn-primary" data-dismiss="modal" aria-hidden="true">{{ _('Close') }}</a>


### PR DESCRIPTION
This PR changes the title of the popup to be the name of the UFP file. The popup is made a bit smaller, because the thumbnail files are always created at 300x300 pixels.

I also took the liberty to add a description and remove a todo here and there.