### PR TITLE
0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# OctoPrint-UltimakerFormatPackage
+# Cura Thumbnails
+
+(formerly Ultimaker Format Package)
 
 This plugin adds support for Ultimaker Format Package (.ufp) files. Ultimaker Format Package files are based on Open Packaging Conventions (OPC) and contain compressed gcode and a preview thumbnail. This format will automatically be used by the [OctoPrint Connection](https://github.com/fieldOfView/Cura-OctoPrintPlugin) plugin in Cura (install via Marketplace) if this plugin is installed.
 

--- a/octoprint_ultimakerformatpackage/templates/UltimakerFormatPackage_settings.jinja2
+++ b/octoprint_ultimakerformatpackage/templates/UltimakerFormatPackage_settings.jinja2
@@ -1,4 +1,4 @@
-<h3>{{ _('Ultimaker Format Package') }} <small>{{ _('Version') }}: <span data-bind="text: settings.plugins.UltimakerFormatPackage.installed_version"/></small></h3>
+<h3>{{ _('Cura Thumbnails') }} <small>{{ _('Version') }}: <span data-bind="text: settings.plugins.UltimakerFormatPackage.installed_version"/></small></h3>
 <div class="control-group">
 	<div class="controls">
 		<label class="checkbox">

--- a/setup.py
+++ b/setup.py
@@ -1,73 +1,25 @@
 # coding=utf-8
 
-########################################################################################################################
-### Do not forget to adjust the following variables to your own plugin.
-
-# The plugin's identifier, has to be unique
 plugin_identifier = "UltimakerFormatPackage"
-
-# The plugin's python package, should be "octoprint_<plugin identifier>", has to be unique
 plugin_package = "octoprint_ultimakerformatpackage"
-
-# The plugin's human readable name. Can be overwritten within OctoPrint's internal data via __plugin_name__ in the
-# plugin module
 plugin_name = "OctoPrint-UltimakerFormatPackage"
-
-# The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.9"
-
-# The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
-# module
+plugin_version = "0.2.0"
 plugin_description = """Plugin that allows the upload of Cura exported ufp file format."""
-
-# The plugin's author. Can be overwritten within OctoPrint's internal data via __plugin_author__ in the plugin module
 plugin_author = "jneilliii"
-
-# The plugin's author's mail address.
 plugin_author_email = "jneilliii+github@gmail.com"
-
-# The plugin's homepage URL. Can be overwritten within OctoPrint's internal data via __plugin_url__ in the plugin module
 plugin_url = "https://github.com/jneilliii/OctoPrint-UltimakerFormatPackage"
-
-# The plugin's license. Can be overwritten within OctoPrint's internal data via __plugin_license__ in the plugin module
 plugin_license = "AGPLv3"
-
-# Any additional requirements besides OctoPrint should be listed here
 plugin_requires = []
-
-### --------------------------------------------------------------------------------------------------------------------
-### More advanced options that you usually shouldn't have to touch follow after this point
-### --------------------------------------------------------------------------------------------------------------------
-
-# Additional package data to install for this plugin. The subfolders "templates", "static" and "translations" will
-# already be installed automatically if they exist. Note that if you add something here you'll also need to update
-# MANIFEST.in to match to ensure that python setup.py sdist produces a source distribution that contains all your
-# files. This is sadly due to how python's setup.py works, see also http://stackoverflow.com/a/14159430/2028598
 plugin_additional_data = []
-
-# Any additional python packages you need to install with your plugin that are not contained in <plugin_package>.*
 plugin_additional_packages = []
-
-# Any python packages within <plugin_package>.* you do NOT want to install with your plugin
 plugin_ignored_packages = []
-
-# Additional parameters for the call to setuptools.setup. If your plugin wants to register additional entry points,
-# define dependency links or other things like that, this is the place to go. Will be merged recursively with the
-# default setup parameters as provided by octoprint_setuptools.create_plugin_setup_parameters using
-# octoprint.util.dict_merge.
-#
-# Example:
-#     plugin_requires = ["someDependency==dev"]
-#     additional_setup_parameters = {"dependency_links": ["https://github.com/someUser/someRepo/archive/master.zip#egg=someDependency-dev"]}
 additional_setup_parameters = {}
-
-########################################################################################################################
 
 from setuptools import setup
 
 try:
 	import octoprint_setuptools
-except:
+except ImportError:
 	print("Could not import OctoPrint's setuptools, are you sure you are running that under "
 	      "the same python installation that OctoPrint is installed under?")
 	import sys


### PR DESCRIPTION
rename plugin to `Cura Thumbnails`
fix bug with not removing temporary gcode files
fix issue where thumbnails were not getting deleted if they were uploaded since last octoprint restart
add no exclude data files (thumbnails) from backup if gcode files are excluded, requires OctoPrint 1.5.0