### PR TITLE
Some `.ufp` might not contain thumbnails

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark Stale Issues
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "0 0 * * *"
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had activity in 14 days. It will be closed if no further activity occurs in 7 days'
+        days-before-stale: 14
+        days-before-close: 7
+        stale-issue-label: 'stale'
+        days-before-issue-stale: 14
+        days-before-pr-stale: -1
+        days-before-issue-close: 7
+        days-before-pr-close: -1
+        exempt-issue-labels: 'bug,enhancement'

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Check out my other plugins [here](https://plugins.octoprint.org/by_author/#jneil
 - [SimplyPrint](https://simplyprint.dk/)
 - [Andrew Beeman](https://github.com/Kiendeleo)
 - [Calanish](https://github.com/calanish)
+- [Will O](https://github.com/4wrxb)
 
 ### Support My Efforts
 I, jneilliii, programmed this plugin for fun and do my best effort to support those that have issues with it, please return the favor and leave me a tip or become a Patron if you find this plugin helpful and want me to continue future development.

--- a/octoprint_ultimakerformatpackage/__init__.py
+++ b/octoprint_ultimakerformatpackage/__init__.py
@@ -265,6 +265,16 @@ class UltimakerFormatPackagePlugin(octoprint.plugin.SettingsPlugin,
 				user="jneilliii",
 				repo="OctoPrint-UltimakerFormatPackage",
 				current=self._plugin_version,
+                stable_branch=dict(
+                    name="Stable", branch="master", comittish=["master"]
+                ),
+                prerelease_branches=[
+                    dict(
+                        name="Release Candidate",
+                        branch="rc",
+                        comittish=["rc", "master"],
+                    )
+                ],
 
 				# update method: pip
 				pip="https://github.com/jneilliii/OctoPrint-UltimakerFormatPackage/archive/{target_version}.zip"

--- a/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
+++ b/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
@@ -104,7 +104,7 @@ $(function() {
 						if($('#UFP_state_thumbnail').length){
 							$('#UFP_state_thumbnail > img').attr('src', ((data.thumbnail) ? data.thumbnail : 'plugin/UltimakerFormatPackage/thumbnail/' + data.path.replace('.ufp.gcode','.png')));
 						} else {
-							$('#state > div > hr:nth-child(4)').after('<div id="UFP_state_thumbnail" class="row-fluid"><img src="'+((data.thumbnail) ? data.thumbnail : 'plugin/UltimakerFormatPackage/thumbnail/' + data.path.replace('.ufp.gcode','.png'))+'" width="100%"/>\n<hr/></div>');
+							$('#state > div > hr:first').after('<div id="UFP_state_thumbnail" class="row-fluid"><img src="'+((data.thumbnail) ? data.thumbnail : 'plugin/UltimakerFormatPackage/thumbnail/' + data.path.replace('.ufp.gcode','.png'))+'" width="100%"/>\n<hr/></div>');
 						}
 					} else {
 						$('#UFP_state_thumbnail').remove();

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 plugin_identifier = "UltimakerFormatPackage"
 plugin_package = "octoprint_ultimakerformatpackage"
 plugin_name = "OctoPrint-UltimakerFormatPackage"
-plugin_version = "0.2.0"
+plugin_version = "0.2.1"
 plugin_description = """Plugin that allows the upload of Cura exported ufp file format."""
 plugin_author = "jneilliii"
 plugin_author_email = "jneilliii+github@gmail.com"


### PR DESCRIPTION
Some gcodes uploaded from Cura might not contain thumbnails.
Without this it will result in `500 Internal Server Error`.

This results in:

```
2021-02-03 21:58:52,183 - octoprint.filemanager - ERROR - Error when calling preprocessor hook for plugin UltimakerFormatPackage, ignoring
Traceback (most recent call last):
  File "/opt/octoprint/.local/lib/python3.7/site-packages/octoprint/filemanager/__init__.py", line 718, in add_file
    allow_overwrite=allow_overwrite,
  File "/opt/octoprint/.local/lib/python3.7/site-packages/octoprint/util/__init__.py", line 1890, in wrapper
    return f(*args, **kwargs)
  File "/opt/octoprint/.local/lib/python3.7/site-packages/octoprint_ultimakerformatpackage/__init__.py", line 226, in ufp_upload
    thumbnail.write(zipObj.read("/Metadata/thumbnail.png"))
  File "/usr/lib/python3.7/zipfile.py", line 1428, in read
    with self.open(name, "r", pwd) as fp:
  File "/usr/lib/python3.7/zipfile.py", line 1467, in open
    zinfo = self.getinfo(name)
  File "/usr/lib/python3.7/zipfile.py", line 1395, in getinfo
    'There is no item named %r in the archive' % name)
KeyError: "There is no item named '/Metadata/thumbnail.png' in the archive"
```

NOTICE: I still need to test exactly this change on Octoprint :)