### PR TITLE
duplicated gcode extensions

### DIFF
--- a/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
+++ b/octoprint_ultimakerformatpackage/static/js/UltimakerFormatPackage.js
@@ -26,13 +26,13 @@ $(function() {
 				self.file_details(data);
 				$('div#UltimakerFormatPackage_thumbnail_viewer').modal("show");
 			}
-		}
+		};
 
-		self.DEFAULT_THUMBNAIL_SCALE = "100%"
-		self.filesViewModel.UFPthumbnailScaleValue = ko.observable(self.DEFAULT_THUMBNAIL_SCALE)
+		self.DEFAULT_THUMBNAIL_SCALE = "100%";
+		self.filesViewModel.UFPthumbnailScaleValue = ko.observable(self.DEFAULT_THUMBNAIL_SCALE);
 
-		self.DEFAULT_THUMBNAIL_ALIGN = "left"
-		self.filesViewModel.UFPthumbnailAlignValue = ko.observable(self.DEFAULT_THUMBNAIL_ALIGN)
+		self.DEFAULT_THUMBNAIL_ALIGN = "left";
+		self.filesViewModel.UFPthumbnailAlignValue = ko.observable(self.DEFAULT_THUMBNAIL_ALIGN);
 
         self.DEFAULT_THUMBNAIL_POSITION = false;
 		self.filesViewModel.UFPthumbnailPositionLeft = ko.observable(self.DEFAULT_THUMBNAIL_POSITION);
@@ -56,15 +56,15 @@ $(function() {
 				}
 
 				console.log(data);
-				if(self.crawl_results().length == 0){
+				if(self.crawl_results().length === 0){
 					self.crawl_results.push({name: ko.observable('No convertible files found'), files: ko.observableArray([])});
 				}
 				self.filesViewModel.requestData({force: true});
 				self.crawling_files(false);
 			}).fail(function(data){
 				self.crawling_files(false);
-			})
-		}
+			});
+		};
 
 		self.onBeforeBinding = function() {
 			// assign initial scaling
@@ -99,7 +99,7 @@ $(function() {
 				self.filesViewModel.UFPthumbnailScaleValue(newValue + "%");
 			});
 			self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail_scale_value.subscribe(function(newValue){
-				$('#UFP_state_thumbnail').attr({'width': self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail_scale_value() + '%'})
+				$('#UFP_state_thumbnail').attr({'width': self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail_scale_value() + '%'});
 			});
 
 			// observe alignment changes
@@ -129,8 +129,8 @@ $(function() {
 			self.filesViewModel.listHelper.selectedItem.subscribe(function(data){
 				// remove the state panel thumbnail in case it's already there
 				if(data){
-					console.log(self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail() && (data.thumbnail || data.name.indexOf('.ufp.gcode') > 0) && (data.thumbnail_src == 'UltimakerFormatPackage' || data.name.indexOf('.ufp.gcode') > 0));
-					if(self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail() && (data.thumbnail || data.name.indexOf('.ufp.gcode') > 0) && (data.thumbnail_src == 'UltimakerFormatPackage' || data.name.indexOf('.ufp.gcode') > 0)){
+					console.log(self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail() && (data.thumbnail || data.name.indexOf('.ufp.gcode') > 0) && (data.thumbnail_src === 'UltimakerFormatPackage' || data.name.indexOf('.ufp.gcode') > 0));
+					if(self.settingsViewModel.settings.plugins.UltimakerFormatPackage.state_panel_thumbnail() && (data.thumbnail || data.name.indexOf('.ufp.gcode') > 0) && (data.thumbnail_src === 'UltimakerFormatPackage' || data.name.indexOf('.ufp.gcode') > 0)){
 						if($('#UFP_state_thumbnail').length){
 							$('#UFP_state_thumbnail > img').attr('src', data.thumbnail);
 						} else {
@@ -143,7 +143,7 @@ $(function() {
 					$('#UFP_state_thumbnail').remove();
 				}
 			});
-		}
+		};
 
 		$(document).ready(function(){
 			let regex = /<div class="btn-group action-buttons">([\s\S]*)<.div>/mi;
@@ -154,12 +154,12 @@ $(function() {
 			                                'visible: $data.thumbnail_src == \'UltimakerFormatPackage\' && $root.settingsViewModel.settings.plugins.UltimakerFormatPackage.inline_thumbnail() == true, ' +
 			                                'click: function() { if ($root.loginState.isUser()) { $root.UltimakerFormatPackage_open_thumbnail($data) } else { return; } },' +
                                             'style: {\'width\': (!$root.UFPthumbnailPositionLeft()) ? $root.UFPthumbnailScaleValue() : \'100%\' }" ' +
-			                                'style="display: none;"/></div>'
+			                                'style="display: none;"/></div>';
 
 			$("#files_template_machinecode").text(function () {
 				var return_value = inline_thumbnail_template + $(this).text();
 				return_value = return_value.replace(regex, '<div class="btn-group action-buttons">$1	' + template + '></div>');
-				return return_value
+				return return_value;
 			});
 		});
 	}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 plugin_identifier = "UltimakerFormatPackage"
 plugin_package = "octoprint_ultimakerformatpackage"
 plugin_name = "OctoPrint-UltimakerFormatPackage"
-plugin_version = "1.0.0"
+plugin_version = "1.0.1rc1"
 plugin_description = """Plugin that allows the upload of Cura exported ufp file format."""
 plugin_author = "jneilliii"
 plugin_author_email = "jneilliii+github@gmail.com"


### PR DESCRIPTION
fix issues related to filenames with `.gcode.gcode` instead of just `filename.gcode`, resolves #34 